### PR TITLE
fix: use explicit length check for chezmoi_init_url conditional

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,12 +12,12 @@
 
 - name: Initialize chezmoi (empty)
   ansible.builtin.command: "chezmoi init"
-  when: not chezmoi_init_url
+  when: chezmoi_init_url | length == 0
   args:
     creates: "~/.local/share/chezmoi"
 
 - name: Initialize chezmoi
   ansible.builtin.command: "chezmoi init --apply --verbose {{ chezmoi_init_url }}"
-  when: chezmoi_init_url
+  when: chezmoi_init_url | length > 0
   args:
     creates: "~/.local/share/chezmoi"


### PR DESCRIPTION
## Summary
- Replace `when: chezmoi_init_url` / `when: not chezmoi_init_url` with `| length > 0` / `| length == 0` checks
- Fixes deprecation warning in ansible-core 2.24+ where implicit string-to-boolean conversion in `when` conditionals is no longer allowed

The default value of `chezmoi_init_url` is `""` (empty string). Using it directly in a `when` conditional produces:

```
Conditional result (False) was derived from value of type 'str'.
Conditionals must have a boolean result.
```

## Test plan
- [ ] Run the role with `chezmoi_init_url` unset (default `""`) — should run "Initialize chezmoi (empty)" task
- [ ] Run the role with `chezmoi_init_url` set to a GitHub username — should run "Initialize chezmoi" task

🤖 Generated with [Claude Code](https://claude.com/claude-code)