### PR TITLE
ci: update OS test matrix to include Debian 13 and remove Fedora

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,14 @@ jobs:
     strategy:
       matrix:
         distro:
-          - debian11
+          - debian13
+          - debian12
+          - ubuntu2404
           - ubuntu2204
-        chezmoi_version: ["v2.31.0"]
+        chezmoi_version: ["v2.70.0"]
         unreliable: [false]
         include:
-          - distro: ubuntu2204
+          - distro: ubuntu2404
             chezmoi_version: ""
             unreliable: true
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,9 +11,11 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - jammy
+    - noble
   - name: Debian
     versions:
-    - bullseye
+    - bookworm
+    - trixie
 
   galaxy_tags:
     - dotfiles

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest
+    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2404}-ansible:latest
     pre_build_image: true
 provisioner:
   name: ansible


### PR DESCRIPTION
Updates the CI test matrix and role metadata to include modern OS distributions (Ubuntu 24.04, Debian 12, Debian 13) and removes Fedora support. Also bumps the default Molecule distribution to Ubuntu 24.04.