### PR TITLE
fix: use failed_when instead of ignore_errors for missing chezmoi check

### DIFF
--- a/tasks/download-chezmoi.yml
+++ b/tasks/download-chezmoi.yml
@@ -19,7 +19,7 @@
 - name: Check if chezmoi is already installed
   ansible.builtin.command: chezmoi --version
   register: chezmoi_version_output
-  ignore_errors: true
+  failed_when: chezmoi_version_output.rc not in [0, 2]
   changed_when: false
 
 - name: Determine chezmoi version and other variables


### PR DESCRIPTION
Replaces ignore_errors: true with failed_when: false in the chezmoi presence check to avoid misleading red error messages in the output when chezmoi is not installed.