### PR TITLE
ci: remove unsupported OS distros and Fedora

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,7 @@ jobs:
       matrix:
         distro:
           - debian11
-          - debian10
           - ubuntu2204
-          - ubuntu2004
-          - fedora37
-          - fedora36
         chezmoi_version: ["v2.31.0"]
         unreliable: [false]
         include:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,25 +7,13 @@ galaxy_info:
 
   min_ansible_version: "2.9"
 
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
   platforms:
   - name: Ubuntu
     versions:
-    - bionic
-    - focal
     - jammy
   - name: Debian
     versions:
-    - jessie
-    - stretch
-    - buster
     - bullseye
-  - name: Fedora
-    versions:
-    - "36"
-    - "37"
 
   galaxy_tags:
     - dotfiles


### PR DESCRIPTION
Removes Debian 10, Ubuntu 20.04, and all Fedora versions from the CI matrix and role metadata.