### PR TITLE
ci: configure working directory and checkout path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+defaults:
+  run:
+    working-directory: 'hussainweb.chezmoi'
+
 jobs:
   test:
     name: Molecule
@@ -26,6 +30,8 @@ jobs:
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v4
+        with:
+          path: 'hussainweb.chezmoi'
 
       - name: Set up Python 3.
         uses: actions/setup-python@v5
@@ -33,7 +39,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker] yamllint ansible-lint
+        run: pip3 install ansible molecule[docker] yamllint ansible-lint
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] yamllint ansible-lint
+        run: pip3 install ansible molecule molecule-plugins[docker] yamllint ansible-lint
 
       - name: Run Molecule tests.
         run: molecule test

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,9 +2,9 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: "Include ansible-role-chezmoi"
+    - name: "Include hussainweb.chezmoi"
       ansible.builtin.include_role:
-        name: "ansible-role-chezmoi"
+        name: "hussainweb.chezmoi"
       vars:
         chezmoi_init_url: "https://github.com/hussainweb/ansible-test-chezmoi"
         chezmoi_version: "{{ lookup('ansible.builtin.env', 'CHEZMOI_VERSION')|default('') }}"


### PR DESCRIPTION
Sets a specific checkout path and working directory in the CI workflow to improve role discovery in Molecule tests. Also updates converge.yml to use the matching role name.