### PR TITLE
ci: add Rocky Linux support and use dnf for RPMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           - debian12
           - ubuntu2404
           - ubuntu2204
+          - rockylinux10
+          - rockylinux9
         chezmoi_version: ["v2.70.0"]
         unreliable: [false]
         include:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ ansible-galaxy collection install community.general
 - Ubuntu 24.04 (Noble)
 - Debian 12 (Bookworm)
 - Debian 13 (Trixie)
+- Rocky Linux 9
+- Rocky Linux 10
 
 ## Role Variables
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,10 @@ galaxy_info:
     versions:
     - bookworm
     - trixie
+  - name: EL
+    versions:
+    - "9"
+    - "10"
 
   galaxy_tags:
     - dotfiles

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -12,10 +12,11 @@
         state: present
       when: ansible_facts['os_family'] == "Debian"
     - name: Install packages (redhat)
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         name:
           - curl
           - git
         update_cache: yes
         state: present
+        allowerasing: true
       when: ansible_facts['os_family'] == "RedHat"

--- a/tasks/download-chezmoi.yml
+++ b/tasks/download-chezmoi.yml
@@ -34,7 +34,7 @@
   become: true
 
 - name: "Install (rpm) chezmoi v{{ chezmoi_version_filtered }}"
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "https://github.com/twpayne/chezmoi/releases/download/v{{ chezmoi_version_filtered }}/chezmoi-{{ chezmoi_version_filtered }}-{{ chezmoi_redhat_architectures[ansible_facts['architecture']] }}.rpm"
     state: present
     disable_gpg_check: yes  # GPG check fails for some reason.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,11 +15,9 @@
   when: chezmoi_init_url | length == 0
   args:
     creates: "~/.local/share/chezmoi"
-  become: true
 
 - name: Initialize chezmoi
   ansible.builtin.command: "chezmoi init --apply --verbose {{ chezmoi_init_url }}"
   when: chezmoi_init_url | length > 0
   args:
     creates: "~/.local/share/chezmoi"
-  become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,9 +15,11 @@
   when: chezmoi_init_url | length == 0
   args:
     creates: "~/.local/share/chezmoi"
+  become: true
 
 - name: Initialize chezmoi
   ansible.builtin.command: "chezmoi init --apply --verbose {{ chezmoi_init_url }}"
   when: chezmoi_init_url | length > 0
   args:
     creates: "~/.local/share/chezmoi"
+  become: true


### PR DESCRIPTION
This PR adds support for Rocky Linux 9 and 10 to the CI matrix and metadata. It also updates the RPM installation task to use the more modern  module instead of .